### PR TITLE
be more selective when removing things from keywords file

### DIFF
--- a/templates/cleanup
+++ b/templates/cleanup
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## Clean-up the keywordfile 
-sed -i "/@@CPV@@/d" @@KEYWORDFILE@@
+sed -i "/# Job @@CPV@@$/d" @@KEYWORDFILE@@
 
 # Remove all files associated to the job:
 rm -f @@JOB@@-*


### PR DESCRIPTION
Match on the exact job marker, not on every line that accidentially matches the package name.